### PR TITLE
docs: update README, architecture docs, and add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Agents Guide for aecomet.github.io
+
+## Tech Stack
+
+- **Runtime**: Node.js 26.3.0
+- **Language**: TypeScript (strict mode)
+- **Framework**: Vue 3 (Composition API / `<script setup>`)
+- **UI Library**: Vuetify 4 (mdi-svg iconset via `@mdi/js`)
+- **Router**: Vue Router 5 (hash history)
+- **Build**: Vite 8 + vite-ssg (static site generation)
+- **Styling**: SCSS
+- **Formatter**: Prettier
+- **Linter**: ESLint
+- **Package manager**: pnpm 11
+- **Git hooks**: Lefthook (pre-commit: format + lint, pre-push: AI review)
+- **Container**: Docker (multi-stage: node slim → httpd alpine)
+
+## Reference Documents (read before working)
+
+| File                              | Purpose                                               |
+| --------------------------------- | ----------------------------------------------------- |
+| `.github/copilot-instructions.md` | Coding conventions, commit workflow, review checklist |
+| `docs/architecture.md`            | Project structure, routing, build pipeline            |
+| `.agent/tdd/SKILL.md`             | TDD workflow — always follow when writing code        |
+| `README.md`                       | Project overview, getting started                     |
+
+## Skills Available
+
+| Skill | File                  | When to use                           |
+| ----- | --------------------- | ------------------------------------- |
+| `tdd` | `.agent/tdd/SKILL.md` | When writing or modifying source code |
+
+## Key Commands
+
+```sh
+pnpm dev           # Start dev server
+pnpm build         # Build to build/
+pnpm lint          # Run ESLint
+pnpm format:check  # Check formatting
+pnpm format        # Auto-format
+```
+
+## Rules
+
+- All code changes must follow the TDD cycle (RED → GREEN → REFACTOR).
+- Always run `pnpm lint` and `pnpm build` before committing.
+- Commit messages must follow Conventional Commits.
+- Use Vue 3 Composition API with `<script setup>` for all components.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ A personal portfolio site built with Vue 3 + Vuetify, pre-rendered as a static s
 
 ### Prerequisites
 
-- Node.js `24.14.0` (see `.node-version`)
-- pnpm `10`
+- Node.js `26.3.0` (see `.node-version`)
+- pnpm `11`
 
 ```sh
 npm i -g pnpm
@@ -80,4 +80,6 @@ For full architecture details, see [docs/architecture.md](docs/architecture.md).
 | Trigger        | Workflow          | Description                                        |
 | -------------- | ----------------- | -------------------------------------------------- |
 | push to `main` | `app-release.yml` | Build → Deploy to GitHub Pages → Push Docker image |
-| Pull Request   | `lint-runner.yml` | ESLint + Prettier via reviewdog                    |
+| Pull Request   | `ci.yml`          | Format check + ESLint + Build                      |
+| pre-commit     | lefthook          | Format check + ESLint                              |
+| pre-push       | lefthook          | AI code review (blocker/high severity gates)       |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,10 +16,10 @@ This is a static portfolio site built with Vue 3 and Vuetify, pre-rendered via v
 | Language | TypeScript | ^5.9 |
 | Build Tool | Vite | ^8.0 |
 | SSG | vite-ssg | ^28.3 |
-| Icons | @mdi/font | ^7.4 |
+| Icons | @mdi/js (mdi-svg via Vuetify) | ^7.4 |
 | Styling | SCSS | via sass |
-| Package Manager | pnpm | 10 |
-| Container Runtime | Apache httpd (Alpine) | httpd:alpine3.21 |
+| Package Manager | pnpm | 11 |
+| Container Runtime | Apache httpd (Alpine) | httpd:2.4.67-alpine3.23 |
 
 ---
 
@@ -93,14 +93,14 @@ All routes use **lazy loading** (dynamic `import()`) to split bundles per page.
 | Contact | `/contact` | `pages/UserContact.vue` |
 | NotFound | `/:pathMatch(.*)*` | `pages/NotFoundPage.vue` |
 
-History strategy: `createWebHistory` (browser) / `createMemoryHistory` (SSR/SSG).
+History strategy: `createWebHashHistory` (hash-based, for GitHub Pages SPA fallback).
 
 ---
 
 ## UI & Styling
 
 - **Vuetify 4** provides the component library and dark theme.
-- **@mdi/font** is used for all icons (`mdi-*` prefix).
+- **@mdi/js** (mdi-svg via `vuetify/iconsets/mdi-svg`) is used for all icons, replacing the legacy `@mdi/font` CSS bundle (472KB → 198KB CSS reduction).
 - Global styles are defined in `src/assets/style.scss` using CSS custom properties (`--bg`, `--accent1`, etc.).
 - Font families loaded from Google Fonts: `Syne`, `Noto Sans JP`, `DM Mono` (all with `display=swap`).
 
@@ -140,7 +140,11 @@ push to main
         └── 3. Build image    (Docker multi-arch: amd64 + arm64 → ghcr.io)
 ```
 
-Code quality is enforced on pull requests via `lint-runner.yml` (ESLint + Prettier through reviewdog).
+Code quality is enforced via:
+
+- **Pull requests**: `ci.yml` — format check (`prettier --check`) + ESLint + Vite build.
+- **pre-commit (lefthook)**: format check + ESLint (blocks commit on failure).
+- **pre-push (lefthook)**: AI code review (`scripts/review-diff.sh`) with severity tiers — Blocker and High findings block the push.
 
 ---
 
@@ -150,8 +154,8 @@ Multi-stage build:
 
 | Stage | Base Image | Purpose |
 |-------|-----------|---------|
-| `builder` | `node:24.14.0-slim` | Install dependencies, run `pnpm build` |
-| runtime | `httpd:alpine3.21` | Serve `/build` as static files |
+| `builder` | `node:26.3.0-slim` | Install dependencies, run `pnpm build` |
+| runtime | `httpd:2.4.67-alpine3.23` | Serve `/build` as static files |
 
 Port: `8888`. Runs as `www-data` user with minimal capabilities.
 


### PR DESCRIPTION
Update docs to reflect recent maintenance changes: pnpm v11, hash routing, mdi-svg migration, lefthook CI, Node 26.3.0. Add AGENTS.md for AI agent workflows.